### PR TITLE
Implement ShowMore button functionality with state persistence

### DIFF
--- a/ReviewsApp/Screens/Reviews/Cells/ReviewCell.swift
+++ b/ReviewsApp/Screens/Reviews/Cells/ReviewCell.swift
@@ -57,7 +57,15 @@ extension ReviewCellConfig: TableCellConfig {
 		cell.currentLayout = layout
 
 		cell.ratingImage.image = RatingRenderer.shared.ratingImage(rating)
+
+		cell.reviewTextLabel.numberOfLines = maxLines
+		cell.showMoreButton.isHidden = !layout.showShowMoreButton
 		cell.config = self
+
+		cell.showMoreButton.addAction(UIAction { _ in
+			self.onTapShowMore(self.id)
+		}, for: .touchUpInside)
+
     }
 
     /// Метод, возвращаюший высоту ячейки с данным ограничением по размеру.
@@ -172,6 +180,8 @@ private final class ReviewCellLayout {
 
 	// Высота ячейки.
 	private(set) var height: CGFloat = 0
+	// Флаг необходимости отображения кнопки "Показать полностью...".
+	private(set) var showShowMoreButton: Bool = false
 
     // MARK: - Размеры
 
@@ -226,7 +236,6 @@ private final class ReviewCellLayout {
     func height(config: Config, maxWidth: CGFloat) -> CGFloat {
 		var maxX = insets.left
         var maxY = insets.top
-        var showShowMoreButton = false
 
 		avatarImageFrame = CGRect(
 			origin: CGPoint(x: maxX, y: maxY),


### PR DESCRIPTION
### Summary
This PR finalizes the implementation of the **ShowMore button** in `ReviewCell`.

### Features
- Expands review text to full height when the button is tapped.
- Maintains correct expanded/collapsed state when scrolling and reusing cells.

### Technical details
- Explicitly sets `reviewTextLabel.numberOfLines` and `showMoreButton.isHidden` in `update(cell:)` to avoid UI reuse issues.

### Testing
- Verified initial load with mixed reviews (short and long).
- Confirmed that tapping “Show More” on multiple cells expands text as expected.
- Tested scrolling up and down multiple times.