### PR TITLE
Refactor reviews reload logic: use reloadRows, split state callbacks, remove cell flicker

### DIFF
--- a/ReviewsApp/Screens/Reviews/ReviewsViewController.swift
+++ b/ReviewsApp/Screens/Reviews/ReviewsViewController.swift
@@ -39,9 +39,15 @@ private extension ReviewsViewController {
     }
 
     func setupViewModel() {
-        viewModel.onStateChange = { [weak reviewsView] _ in
-            reviewsView?.tableView.reloadData()
-        }
+		viewModel.onItemsChanged = { [weak reviewsView] _ in
+			reviewsView?.tableView.reloadData()
+		}
+
+		viewModel.onReviewUpdated = { [weak reviewsView] indexPath in
+			UIView.performWithoutAnimation {
+				reviewsView?.tableView.reloadRows(at: [indexPath], with: .none)
+			}
+		}
     }
 
 }

--- a/ReviewsApp/Screens/Reviews/ReviewsViewModel.swift
+++ b/ReviewsApp/Screens/Reviews/ReviewsViewModel.swift
@@ -4,7 +4,9 @@ import UIKit
 final class ReviewsViewModel: NSObject {
 
     /// Замыкание, вызываемое при изменении `state`.
-    var onStateChange: ((State) -> Void)?
+    var onItemsChanged: ((State) -> Void)?
+	/// Замыкание, вызываемое при изменении `review`.
+	var onReviewUpdated: ((IndexPath) -> Void)?
 
     private var state: State
     private let reviewsProvider: ReviewsProvider
@@ -60,12 +62,12 @@ private extension ReviewsViewModel {
 					if self.state.offset >= reviews.count {
 						self.state.items.append(self.makeReviewsCountItem(totalCount: reviews.count))
 					}
-					self.onStateChange?(self.state)
+					self.onItemsChanged?(self.state)
 				}
 			} catch {
 				DispatchQueue.main.async {
 					self.state.shouldLoad = true
-					self.onStateChange?(self.state)
+					self.onItemsChanged?(self.state)
 				}
 			}
 		}
@@ -80,7 +82,9 @@ private extension ReviewsViewModel {
         else { return }
         item.maxLines = .zero
         state.items[index] = item
-        onStateChange?(state)
+		
+		let indexPath = IndexPath(row: index, section: 0)
+		onReviewUpdated?(indexPath)
     }
 
 }


### PR DESCRIPTION
### Summary

This PR refactors the reviews reload logic to improve performance and user experience.

### Changes

- Replaced `reloadData()` with `reloadRows()` for ShowMore button actions to update only affected cells.
- Split `onStateChange` into two callbacks:
  - `onItemsChanged` for full data reload.
  - `onReviewUpdated` for single cell updates.
- Disabled reloadRows animation using `UIView.performWithoutAnimation` to prevent cell flickering when expanding reviews.

### Notes

- Improves table view performance by avoiding unnecessary full reloads.
- Provides cleaner architecture with separated state change callbacks.